### PR TITLE
Prevent adding data to a destroyed connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,6 +136,7 @@ class MongoAdapter extends Adapter {
    disconnect(callback) {
       this.cursor.close((err) => {
          if (err) return callback(err)
+         clearInterval(this.heartbeatTimer)
          this.model.db.close((connectionErr) => {
             if (typeof callback === 'function') {
                callback(connectionErr)


### PR DESCRIPTION
It happens when the mongoose connection has been disconnected and reconnected programmatically. The underlying Message model used by mongo adapter sometimes will throw errors on the heartbeat event before we have a chance to recreate the socket.io with the updated mongo adapter settings.